### PR TITLE
Automate snapshot date from metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,6 +456,7 @@
     const kpiColors = ['kpi-teal', 'kpi-blue', 'kpi-orange', 'kpi-coral', 'kpi-purple', 'kpi-red', 'kpi-green', 'kpi-yellow'];
 
     // Data - will be updated by the automation script
+    const snapshotDate = 'YYYY-MM-DD';
     const data = [
     {
         "id": 1,
@@ -804,9 +805,9 @@
       }
     });
     // Initialize dashboard
-    function initDashboard() {
-        // Set current date
-        document.getElementById('currentDate').textContent = `Data as of ${new Date().toLocaleDateString()}`;
+      function initDashboard() {
+          const formatted = new Date(snapshotDate).toLocaleDateString('en-GB');
+          document.getElementById('currentDate').textContent = `Data as of ${formatted}`;
 
         // Generate dynamic components
         generateKPICards();


### PR DESCRIPTION
## Summary
- fetch metadata CSV to get snapshot date
- parse key/value CSV structures
- record snapshot date in `index.html`
- display footer date using the snapshot date

## Testing
- `node --check update-data.js`
- `node update-data.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68765e4c591c833094cb34e8094946f3